### PR TITLE
PrintRiderDebugPort asset menu

### DIFF
--- a/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
+++ b/Assets/Plugins/Editor/JetBrains/RiderPlugin.cs
@@ -268,6 +268,12 @@ namespace Plugins.Editor.JetBrains
     {
       return Enabled;
     }
+    
+    [MenuItem("Assets/Print Rider Debug Port", false, 1000)]
+    static void PrintRiderDebugPort()
+    {
+        Log("Debug port: " + GetDebugPort().ToString());
+    }
 
     /// <summary>
     /// Force Unity To Write Project File


### PR DESCRIPTION
Create an asset menu to print the Unity debug port, to save time syncing the whole solution etc.